### PR TITLE
[FEAT] Add Plant Theme

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -60,4 +60,4 @@ export default function Home() {
 	);
 }
 
-const TAGS = [{ label: "hair" }, { label: "fire" }];
+const TAGS = [{ label: "hair" }, { label: "fire" }, { label: "plant" }];

--- a/lib/svg-generator.ts
+++ b/lib/svg-generator.ts
@@ -48,15 +48,12 @@ export async function generateThemedSVG(username: string, themeKey: string) {
 	);
 
 	const defs = backgroundPattern
-  		? `<defs>${backgroundPattern.replace(
-      		/<pattern([^>]*)>/,
-      		`<pattern id="${patternId}"$1>`
-    		)}</defs>`
+		? `<defs>${backgroundPattern.replace(
+			/<pattern([^>]*?)>/g,
+			`<pattern id="${patternId}"$1>`
+			)}</defs>`
   		: "";
-
 	const fillValue = backgroundPattern ? `url(#${patternId})` : background;
-	console.log("defs:", defs);
-	console.log("fillValue:", fillValue);
 
 	const svg = `
     <svg xmlns="http://www.w3.org/2000/svg" width="${weeks.length * cellSize + 40}" height="180">

--- a/lib/svg-generator.ts
+++ b/lib/svg-generator.ts
@@ -10,6 +10,9 @@ export async function generateThemedSVG(username: string, themeKey: string) {
 	const cellSize = 14;
 
 	const background = theme.background || "#ffffff";
+	const backgroundPattern = theme.backgroundPattern;
+	const patternId = `pattern_${themeKey}`;
+
 	const baseDot = theme.showBaseDot ?? false;
 
 	const elements = weeks.flatMap((week, weekIndex) =>
@@ -44,9 +47,21 @@ export async function generateThemedSVG(username: string, themeKey: string) {
 		}),
 	);
 
+	const defs = backgroundPattern
+  		? `<defs>${backgroundPattern.replace(
+      		/<pattern([^>]*)>/,
+      		`<pattern id="${patternId}"$1>`
+    		)}</defs>`
+  		: "";
+
+	const fillValue = backgroundPattern ? `url(#${patternId})` : background;
+	console.log("defs:", defs);
+	console.log("fillValue:", fillValue);
+
 	const svg = `
     <svg xmlns="http://www.w3.org/2000/svg" width="${weeks.length * cellSize + 40}" height="180">
-      <rect width="100%" height="100%" fill="${background}" />
+	  ${defs}
+      <rect width="100%" height="100%" fill="${fillValue}" />
       <text x="20" y="30" font-size="16" fill="#333">${theme.emoji || ""} ${username}'s ${theme.label}</text>
       ${elements.join("\n")}
     </svg>

--- a/lib/themes.ts
+++ b/lib/themes.ts
@@ -97,13 +97,6 @@ export const PlantTheme: ThemeStyle = {
 				return null;
 		}
 	},
-	colorMap: {
-		none: "#f0fdf4",
-		low: "#bbf7d0",
-		medium: "#86efac",
-		high: "#4ade80",
-		max: "#f472b6",
-	},
 };
 
 export const themes: Record<string, ThemeStyle> = {

--- a/lib/themes.ts
+++ b/lib/themes.ts
@@ -7,6 +7,7 @@ export interface ThemeStyle {
 	label: string;
 	emoji?: string;
 	background?: string;
+	backgroundPattern?: string;
 	showBaseDot?: boolean;
 }
 
@@ -61,9 +62,54 @@ export const FireTheme: ThemeStyle = {
 	},
 };
 
+export const PlantTheme: ThemeStyle = {
+	label: "Plant",
+	emoji: "🌿",
+	background: "#f0fdf4",
+	backgroundPattern: `
+		<pattern patternUnits="userSpaceOnUse" width="40" height="40">
+			<rect width="40" height="40" fill="#7B4A22" />
+			<ellipse cx="8.2" cy="7.1" rx="5.1" ry="2.2" fill="#A97C50" opacity="0.65"/>
+			<ellipse cx="30.5" cy="15.7" rx="3.8" ry="2.9" fill="#C69C6D" opacity="0.55"/>
+			<ellipse cx="20.1" cy="35.2" rx="4.2" ry="1.7" fill="#8D6748" opacity="0.60"/>
+			<ellipse cx="12.7" cy="28.3" rx="2.9" ry="1.2" fill="#BCA17A" opacity="0.70"/>
+			<circle cx="5.2" cy="5.8" r="1.7" fill="#F9E4B7" opacity="0.80"/>
+			<circle cx="13.1" cy="11.2" r="1.1" fill="#F6D28B" opacity="0.60"/>
+			<circle cx="32.3" cy="8.4" r="1.3" fill="#F9E4B7" opacity="0.90"/>
+			<circle cx="18.7" cy="25.6" r="1.2" fill="#BCA17A" opacity="0.70"/>
+			<circle cx="36.2" cy="36.1" r="1.5" fill="#A97C50" opacity="0.80"/>
+		</pattern>
+  	`,
+	showBaseDot: true,
+	getEmoji: (level: CommitLevel): string | null => {
+		switch (level) {
+			case "none":
+				return null;
+			case "low":
+				return "🫘"; // 씨앗
+			case "medium":
+				return "🌱"; // 새싹
+			case "high":
+				return "🌿"; // 풀잎
+			case "max":
+				return "🌻"; // 꽃
+			default:
+				return null;
+		}
+	},
+	colorMap: {
+		none: "#f0fdf4",
+		low: "#bbf7d0",
+		medium: "#86efac",
+		high: "#4ade80",
+		max: "#f472b6",
+	},
+};
+
 export const themes: Record<string, ThemeStyle> = {
 	hair: HairTheme,
 	fire: FireTheme,
+	plant: PlantTheme,
 };
 
 export function getCommitLevel(commitCount: number): CommitLevel {


### PR DESCRIPTION
## 📌 Summary
- Add new "Plant" theme for contribution chart
- This theme visualizes contribution levels as seed🫘 → sprout🌱 → leaf🌿 → flower 🌻

## 🎯 Motivation
- To provide a more nature-inspired Git style

## 🔧 Changes
- Add `PlantTheme` object in `themes.ts`
- Define custom `backgroundPattern` with SVG soil texture
- Modify `generateThemedSVG` to apply pattern fill

## ✅ Checklist
- [x] Tested new theme locally
- [x] Confirmed SVG renders without errors
- [x] Checked compatibility with existing themes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - "plant" 테마가 추가되어, 식물 테마를 선택할 수 있습니다.
  - 식물 테마에는 새로운 배경 패턴과 식물 관련 이모지가 포함되어 있습니다.

- **개선 사항**
  - SVG 생성 시, 테마에 따라 배경 패턴이 적용되어 더욱 다양한 시각적 스타일을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->